### PR TITLE
lib/paper.c: fix leak of file descriptors

### DIFF
--- a/lib/paper.c
+++ b/lib/paper.c
@@ -120,7 +120,7 @@ char* systempapername(void) {
     char* paperstr;
     char* paperenv;
     const char* paperdef;
-    FILE* ps;
+    FILE* ps = NULL;
     struct stat statbuf;
     const struct paper* pp;
     int c;
@@ -204,6 +204,10 @@ PAPERSIZEVAR, fall-back to the old behaviour.
 	}
     } 
       
+    if (ps) {
+        fclose(ps);
+    }
+
     paperdef = defaultpapername();
     paperstr = malloc((strlen(paperdef) + 1) * sizeof(char));
     


### PR DESCRIPTION
When the /etc/papersize was not containing a valid paper size/format, the systempapername() function would return without properly closing the /etc/papersize, thus leaking a file descriptor...

This issue was causing a test failure for ImageMagick:
https://github.com/ImageMagick/ImageMagick/issues/948